### PR TITLE
tag 1.3.5 -> 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cam-vision",
-  "version": "0.1.0",
+  "version": "1.4.0",
   "description": "Vuejs Webcam component (fork from https://github.com/vinceg/vue-web-cam) with get user media / google imagecapture / google vision api",
   "main": "dist/index.js",
   "author": {


### PR DESCRIPTION
本流の kelvin2go/vue-cam-vision タグ最新が1.3.5 だったため、1.4.0としてリリースタグを打ち直す。